### PR TITLE
Update deprecated Stan syntax

### DIFF
--- a/inst/stan/basics_regression.stan
+++ b/inst/stan/basics_regression.stan
@@ -32,8 +32,8 @@ data {
   int n;
   int sq;
   int p;
-  int<lower=0> counts[q, n];
-  int<lower=0> spikes[sq, n];
+  array[q, n] int<lower=0> counts;
+  array[sq, n] int<lower=0> spikes;
   real as;
   real bs;
   real atheta;
@@ -57,7 +57,7 @@ parameters {
   vector [q] log_mu;
   vector <lower=0> [q] delta;
   simplex[n] tphi;
-  real <lower=0> nu[n];
+  array[n] real <lower=0> nu;
   vector <lower=0> [n] s;
   vector <lower=0> [p] theta;
   vector [l] beta;

--- a/inst/stan/basics_regression_nospikes.stan
+++ b/inst/stan/basics_regression_nospikes.stan
@@ -31,7 +31,7 @@ data {
   int q;
   int n;
   int p;
-  int<lower=0> counts[q, n];
+  array[q, n] int<lower=0> counts;
   vector[q] mu_mu;
   real smu;
   real astwo;


### PR DESCRIPTION
This PR updates your Stan models to use the new `array` syntax, otherwise your package will break with the next version of `rstan`. Thanks!